### PR TITLE
Change to local memory allocation for pin arrays -  Fixes issues #7 and #9

### DIFF
--- a/SevSegShift.h
+++ b/SevSegShift.h
@@ -39,6 +39,7 @@ public:
     const byte numberOfShiftRegisters = 2, // currently const value (not changeable) - maybe in future
     bool isDigitsOnController=false // only Segments are on ShiftRegister - DigitPins are connected to controller
   );
+  virtual ~SevSegShift();
 
   /*
     prepare the SevenSeg-Shift-Register lib


### PR DESCRIPTION
Fixes #7 and #9 

Instead of copying just the pointer of the shiftRegisterMapDigits and
shiftRegisterMapSegments arrays passed to begin, we allocate the memory
for them in SegSevShift and copy the values manually.
This removes the implicit need for passing global/static variables, so
begin can be called with local/temporary memory.

Sorry this took a while. I had no access to hardware to test it until today.

Personally I would have used malloc and memcpy, but I kept it similar to how it is done in SevSeg.
Besides this approach should only be marginally slower and someone who really cares about speed would probably roll their own library anyway...